### PR TITLE
Fix reading multiple references in controller filter

### DIFF
--- a/src/filters/Controller.cpp
+++ b/src/filters/Controller.cpp
@@ -245,7 +245,8 @@ void Controller::updateHook()
         doubles ref_in(inport_sizes[j],0.0);
         references_inport[j].read(ref_in);
         for ( uint i = 0; i < inport_sizes[j]; i++ ) {
-            references[k+i] = ref_in[i];
+            references[k] = ref_in[i];
+            k++;
         }
     }
 


### PR DESCRIPTION
I discovered a bug in the function that reads the data from the input port in the controller filter. `k` is never incremented so port 2 will overwrite the data from port 1. I guess this functionality was never tested? @MaxBaeten did you ever test multiple input references on Amigo?