### PR TITLE
Bugfix Homing

### DIFF
--- a/src/supervisory/Homing.cpp
+++ b/src/supervisory/Homing.cpp
@@ -375,9 +375,9 @@ bool Homing::startHook()
 	Safety_maxJointErrors.set(updated_maxerr);
 
 	//! Initialize refgen
-	pos_inport.read( position );
+	pos_inport.read( desiredPos );
 	for ( uint i = 0; i < N; i++ ){
-		mRefGenerators[i].setRefGen(position[i]);
+		mRefGenerators[i].setRefGen(desiredPos[i]);
 	}
 		
 	return true;


### PR DESCRIPTION
This bug made sure that if you home twice, all joints first moved back to their 0 position. and Homing was started from there.

At the end of the start hook of the homing component, the starting position is read from the encoders and the reference generators are set accordingly. However since the vector desiredPos was still initialized at 0 the refgen was correctly initialized at their current nonzero position. But then immediately move towards 0 since that is in desired pos.
This change makes sure that desiredPos is initialized correctly. And from there each joint is homed.

Note that I am working on a refactor since this homing component is a dragon :)
